### PR TITLE
create a lookup for taxonomy to remove dependence on perl

### DIFF
--- a/build_taxonomy_cache.m
+++ b/build_taxonomy_cache.m
@@ -1,0 +1,86 @@
+%% build_taxonomy_cache
+% Reads all .txt files in the taxa directory and writes taxonomy_cache.mat.
+% Called automatically by get_taxonomy_cache when the cache is missing or stale.
+% Can also be called manually after adding new entries to the taxa directory.
+
+function build_taxonomy_cache(taxa_dir)
+% created 2025/06/07
+
+%% Syntax
+% <../build_taxonomy_cache.m *build_taxonomy_cache*> (taxa_dir)
+
+%% Description
+% Reads all taxon .txt files and builds four lookup structures:
+%   taxon_set    - set of all intermediate taxon names (those with a .txt file)
+%   species_set  - set of all species names (leaf nodes, contain '_')
+%   parent       - map from every node to its parent taxon name
+%   children     - map from every taxon to its direct children (ordered as in .txt file)
+%   species_list - map from every taxon to its full sorted list of descendant species
+%
+% Input:
+% * taxa_dir: optional path to taxa directory (default: taxa/ inside AmPtool)
+%
+% Output:
+% * writes taxonomy_cache.mat to taxa_dir
+
+if nargin < 1
+  taxa_dir = fullfile(fileparts(which('build_taxonomy_cache.m')), 'taxa');
+end
+
+files   = dir(fullfile(taxa_dir, '*.txt'));
+n_txt   = numel(files);
+taxon_names = cellfun(@(f) f(1:end-4), {files.name}, 'UniformOutput', false);
+
+fprintf('Building taxonomy cache from %d taxa files in %s ...\n', n_txt, taxa_dir);
+
+taxon_set = containers.Map(taxon_names, true(1, n_txt));
+parent    = containers.Map('KeyType', 'char', 'ValueType', 'char');
+children  = containers.Map('KeyType', 'char', 'ValueType', 'any');
+
+for i = 1:n_txt
+  t   = taxon_names{i};
+  raw = fileread(fullfile(taxa_dir, [t, '.txt']));
+  lines = strtrim(strsplit(raw, {char(10), char(13)}));
+  lines = lines(~cellfun('isempty', lines));
+  children(t) = lines;
+  for j = 1:numel(lines)
+    parent(lines{j}) = t;
+  end
+end
+
+% Pre-compute species_list for every taxon via a single memoised DFS from root.
+% containers.Map is a handle object so modifications inside the helper persist.
+species_list = containers.Map('KeyType', 'char', 'ValueType', 'any');
+memo_collect_leaves('Animalia', children, taxon_set, species_list);
+
+% Build species_set from the complete species list under Animalia
+all_species = species_list('Animalia');
+species_set = containers.Map(all_species, true(numel(all_species), 1));
+
+out_file = fullfile(taxa_dir, 'taxonomy_cache.mat');
+save(out_file, 'n_txt', 'taxon_set', 'species_set', 'parent', 'children', 'species_list');
+fprintf('Taxonomy cache saved: %d taxa, %d species -> %s\n', n_txt, numel(all_species), out_file);
+end
+
+
+%% memo_collect_leaves
+% Memoised recursive helper — populates species_list for node and all descendants.
+% Total work is O(n) because each node is visited exactly once.
+function leaves = memo_collect_leaves(node, children, taxon_set, species_list)
+if isKey(species_list, node)
+  leaves = species_list(node);
+  return
+end
+if ~isKey(taxon_set, node)
+  % Leaf node (species): its own list is just itself
+  leaves = {node};
+  species_list(node) = leaves;
+  return
+end
+kids   = children(node);
+leaves = {};
+for i = 1:numel(kids)
+  leaves = [leaves; memo_collect_leaves(kids{i}, children, taxon_set, species_list)]; %#ok<AGROW>
+end
+species_list(node) = leaves;
+end

--- a/get_taxonomy_cache.m
+++ b/get_taxonomy_cache.m
@@ -1,0 +1,49 @@
+%% get_taxonomy_cache
+% Returns the in-memory taxonomy cache, rebuilding it automatically when stale.
+
+function TC = get_taxonomy_cache()
+% created 2025/06/07
+
+%% Syntax
+% TC = <../get_taxonomy_cache.m *get_taxonomy_cache*> ()
+
+%% Description
+% Returns a struct with five fields built from the taxa .txt files:
+%   TC.n_txt        - number of .txt files when cache was last built
+%   TC.taxon_set    - containers.Map: taxon name -> true  (intermediate nodes)
+%   TC.species_set  - containers.Map: species name -> true  (leaf nodes)
+%   TC.parent       - containers.Map: node -> parent taxon name
+%   TC.children     - containers.Map: taxon -> cell array of direct children
+%   TC.species_list - containers.Map: taxon -> cell array of all descendant species
+%
+% Stale detection: counts the number of .txt files in the taxa directory.
+% If the count has changed since the cache was built, the cache is rebuilt.
+% The in-memory copy (persistent variable) is reused within a MATLAB session
+% as long as the count matches, so repeated calls are essentially free.
+
+persistent cache
+
+taxa_dir  = fullfile(fileparts(which('get_taxonomy_cache.m')), 'taxa');
+n_txt_now = numel(dir(fullfile(taxa_dir, '*.txt')));
+
+% Return in-memory cache if it is current
+if ~isempty(cache) && cache.n_txt == n_txt_now
+  TC = cache;
+  return
+end
+
+% Check whether the file on disk is also current
+cache_file = fullfile(taxa_dir, 'taxonomy_cache.mat');
+needs_build = true;
+if exist(cache_file, 'file') == 2
+  tmp = load(cache_file, 'n_txt');
+  needs_build = (tmp.n_txt ~= n_txt_now);
+end
+
+if needs_build
+  build_taxonomy_cache(taxa_dir);
+end
+
+cache = load(cache_file);
+TC    = cache;
+end

--- a/lineage.m
+++ b/lineage.m
@@ -4,9 +4,10 @@
 %%
 function classification = lineage(taxon)
 % created 2015/09/18 by Bernd Brandt
+% modified 2025/06/07 by mrke: replaced Perl backend with MATLAB taxonomy cache
 
 %% Syntax
-% classification = <../lineage.m *lineage*> (taxon) 
+% classification = <../lineage.m *lineage*> (taxon)
 
 %% Description
 % gets all taxa in the add_my_pet collection to which a particular taxon belongs
@@ -16,29 +17,33 @@ function classification = lineage(taxon)
 % * character string with name of taxon
 %
 % Output:
-% 
+%
 % * cell string of ordered taxa to which that taxon belongs, starting with Animalia
 
 %% Remarks
-% The root is Animalia. 
-% The classification follows that of Wikipedia
+% The root is Animalia.
+% The classification follows that of Wikipedia.
+% Output includes the input taxon itself as the last element.
 
 %% Example of use
 % classification  = lineage('Gorilla_gorilla')
 
-  WD = pwd;                        % store current path
-  taxa = which('lineage.pl');      % locate DEBtool_M/taxa/
-  taxa = taxa(1:end - 10);         % path to DEBtool_M/taxa/
-  cd(taxa)                         % goto taxa
+  TC = get_taxonomy_cache;
 
-  try
-    classification = textscan(perl('lineage.pl', taxon), '%s'); 
-    classification = classification{1};
-  catch
-    disp(['Warning from lineage: Name ', taxon, ' is not recognized as taxon'])
+  if ~isKey(TC.taxon_set, taxon) && ~isKey(TC.species_set, taxon)
+    fprintf('Warning from lineage: Name %s is not recognized as taxon\n', taxon);
+    classification = {};
+    return
   end
-  
-  cd(WD)                           % goto original path
 
+  % Walk up the parent chain from taxon to root
+  classification = {taxon};
+  node = taxon;
+  while isKey(TC.parent, node)
+    node = TC.parent(node);
+    classification{end+1} = node; %#ok<AGROW>
+  end
+
+  % Reverse so output runs from Animalia (root) down to taxon
+  classification = fliplr(classification);
 end
-

--- a/lineage.m
+++ b/lineage.m
@@ -44,6 +44,6 @@ function classification = lineage(taxon)
     classification{end+1} = node; %#ok<AGROW>
   end
 
-  % Reverse so output runs from Animalia (root) down to taxon
-  classification = fliplr(classification);
+  % Reverse so output runs from Animalia (root) down to taxon, as column to match original
+  classification = fliplr(classification)';
 end

--- a/list_taxa.m
+++ b/list_taxa.m
@@ -2,18 +2,19 @@
 % gets ordered list of all taxa and optionally count AmP members
 
 %%
-function [ol, n_c] = list_taxa (taxon, level, count)
+function [ol, n_c] = list_taxa(taxon, level, count)
 % created 2016/02/25 by Bas Kooijman, modified 2018/06/14, 2024/09/11
+% modified 2025/06/07 by mrke: replaced Perl backend with MATLAB taxonomy cache
 
 %% Syntax
-% [ol, n_c] = <../list_taxa.m *list_taxa*> (taxon, level, count) 
+% [ol, n_c] = <../list_taxa.m *list_taxa*> (taxon, level, count)
 
 %% Description
 % gets an alphabetically ordered list of all taxa that belong to taxon in the add_my_pet collection.
 % if count is specified, the order is by number of AmP members of the taxa
 %
 % Input:
-% 
+%
 % * taxon: optional characterstring with name of taxon (default 'Animalia')
 % * level: optional integer for the level (default: 0)
 %
@@ -29,7 +30,7 @@ function [ol, n_c] = list_taxa (taxon, level, count)
 % * count: optional scalar with lower bound for counting members
 %
 % Output:
-% 
+%
 % * ol: cell string with alphabetically ordered list
 % * n_c: vector with number of members; is empty if count is not specified
 
@@ -41,73 +42,88 @@ function [ol, n_c] = list_taxa (taxon, level, count)
 % * ol = list_taxa('Deuterostomata',4)
 % * ol = list_taxa({},7)
 % * ol = list_taxa('Arthropoda')
-% * [ol, n] = list_taxa('Chondrichthyes',3,10); prt_tab({ol n},{'genus', 'n'},'genera',1) 
+% * [ol, n] = list_taxa('Chondrichthyes',3,10); prt_tab({ol n},{'genus', 'n'},'genera',1)
 
   if ~exist('taxon', 'var') || isempty(taxon)
     taxon = 'Animalia';
   end
-  
+
   if ~exist('level', 'var')
     level = 0;
   end
 
-  WD = pwd;                  % store current path
-  taxa = which('list_taxa.pl'); % locate DEBtool_M/taxa/
-  taxa = taxa(1:end - 12);   % path to DEBtool_M/taxa/
-  cd(taxa)                   % goto taxa
+  TC = get_taxonomy_cache;
 
-  try
-    ol = perl('list_taxa.pl', taxon); ol(end) = [];
-    ol = eval(['{''', strrep(ol, char(10), ''';''') , '''}']);
-    switch level
-      case 0
-        % all nodes and leaves
-        
-      case 1 % exclude leaves
-        ol = ol(cellfun(@isempty, strfind(ol,'_'))); % eliminate leaves
-        
-      case 2 % leaves only
-        ol = ol(~cellfun(@isempty, strfind(ol,'_'))); % leaves only
-        
-      case 3 % genus only
-        ol = ol(~cellfun(@isempty, strfind(ol,'_'))); % leaves only
-        n = length(ol);
-        for i = 1:n
-          genus = strsplit(ol{i},'_'); genus = genus{1}; ol{i} = genus;
-        end
-        ol = unique(ol);
-        
-      case 4 % family only
-         ol = ol(~cellfun(@isempty, strfind(ol,'idae'))); 
-         
-      case 5 % order only
-         ol = ol(ismember(ol, unique(read_allStat('order'))));
-
-      case 6 % class only; does not work for Reptilia
-         ol = ol(ismember(ol, unique(read_allStat('class'))));
-
-      case 7 % phylum only
-         ol = ol(ismember(ol, unique(read_allStat('phylum'))));
-
-    end
-    
-  catch
+  if ~isKey(TC.taxon_set, taxon)
     disp('taxon not recognized')
+    ol = {}; n_c = [];
+    return
   end
-  
-  cd(WD)                    % goto original path
-  
-  % count members
+
+  % Collect all descendants (both intermediate taxa and species) plus taxon itself
+  all_nodes = [{taxon}; collect_all_nodes(taxon, TC)];
+  ol = sort(all_nodes);
+
+  switch level
+    case 0
+      % all nodes and leaves — already done
+
+    case 1  % exclude leaves (species have '_')
+      ol = ol(cellfun(@isempty, strfind(ol, '_')));
+
+    case 2  % leaves only
+      ol = ol(~cellfun(@isempty, strfind(ol, '_')));
+
+    case 3  % genus only
+      ol = ol(~cellfun(@isempty, strfind(ol, '_')));
+      n  = length(ol);
+      for i = 1:n
+        parts = strsplit(ol{i}, '_');
+        ol{i} = parts{1};
+      end
+      ol = unique(ol);
+
+    case 4  % family only
+      ol = ol(~cellfun(@isempty, strfind(ol, 'idae')));
+
+    case 5  % order only
+      ol = ol(ismember(ol, unique(read_allStat('order'))));
+
+    case 6  % class only; does not work for Reptilia
+      ol = ol(ismember(ol, unique(read_allStat('class'))));
+
+    case 7  % phylum only
+      ol = ol(ismember(ol, unique(read_allStat('phylum'))));
+  end
+
+  % Count members per taxon if requested
   n_c = [];
-  if exist('count','var') && count >= 0
-    n = length(ol); n_c = zeros(n,1);
+  if exist('count', 'var') && count >= 0
+    n   = length(ol);
+    n_c = zeros(n, 1);
     for i = 1:n
       n_c(i) = length(select(ol{i}));
-    end  
-    sel = n_c >= count;
-    ol = ol(sel); n_c = n_c(sel);
-    [n_c, ind] = sort(n_c,'descend'); ol = ol(ind);
+    end
+    sel  = n_c >= count;
+    ol   = ol(sel);
+    n_c  = n_c(sel);
+    [n_c, ind] = sort(n_c, 'descend');
+    ol   = ol(ind);
   end
-
 end
 
+
+%% collect_all_nodes
+% Returns all descendants of node (both intermediate taxa and species leaves),
+% excluding node itself. Uses the children map for an in-memory DFS.
+function nodes = collect_all_nodes(node, TC)
+  nodes = {};
+  if ~isKey(TC.children, node)
+    return  % leaf node: no children
+  end
+  kids = TC.children(node);
+  for i = 1:numel(kids)
+    nodes{end+1} = kids{i}; %#ok<AGROW>
+    nodes = [nodes; collect_all_nodes(kids{i}, TC)]; %#ok<AGROW>
+  end
+end

--- a/pedigree.m
+++ b/pedigree.m
@@ -4,9 +4,10 @@
 %%
 function [tree, nm, val, units, label] = pedigree(taxon, var)
 % created 2015/09/18 by Bernd Brandt; modified 2017/12/14 by Bas Kooijman
+% modified 2025/06/07 by mrke: replaced Perl backend with MATLAB taxonomy cache
 
 %% Syntax
-% tree = <../pedigree.m *pedigree*> (taxon) 
+% tree = <../pedigree.m *pedigree*> (taxon)
 
 %% Description
 % gets a tree of all species in the add_my_pet collection that belong to a
@@ -19,15 +20,15 @@ function [tree, nm, val, units, label] = pedigree(taxon, var)
 % * var: character string with parameter or statistic
 %
 % Output:
-% 
+%
 % * character string with a tree of all species in the add_my_pet collection that belong to that taxon
 % * nm: n-cellstring with names of entries (non-empty if var is specified)
 % * val: n-vector with values for parameter or statistic (non-empty if var is specified)
-% * units: charactore string with units (non-empty if var is specified)
-% * label: charactore string with label (non-empty if var is specified)
+% * units: character string with units (non-empty if var is specified)
+% * label: character string with label (non-empty if var is specified)
 
 %% Remarks
-% The default root is Animalia. 
+% The default root is Animalia.
 % If chosen as taxon, a tree of all species in the collection results.
 % New lines are written with char(10), tabs with char(9).
 % The classification follows that of Wikipedia.
@@ -37,33 +38,45 @@ function [tree, nm, val, units, label] = pedigree(taxon, var)
 %% Example of use
 % tree  = pedigree or tree = pedigree('Mollusca') or pedigree('Alcidae', 'p_M')
 
-  WD = pwd;                 % store current path
-  taxa = which('pedigree.pl'); % 
-  taxa = taxa(1:end - 11);  % 
-  cd(taxa)                  % goto taxa
-
   if ~exist('taxon', 'var')
     taxon = 'Animalia';
   end
-  
-  try
-    tree = perl('pedigree.pl', taxon); 
-  catch
-    disp(['Warning from pedigree: Name ', taxon, ' is not recognized as taxon'])
+
+  TC = get_taxonomy_cache;
+
+  if ~isKey(TC.taxon_set, taxon)
+    fprintf('Warning from pedigree: Name %s is not recognized as taxon\n', taxon);
+    tree = ''; nm = []; val = []; units = ''; label = '';
+    return
   end
-  
-  cd(WD)                    % goto original path
-  
+
+  % Build indented tree string (taxon at level 0, children indented with tabs)
+  tree = [taxon, char(10), build_pedigree_string(taxon, TC, 1)];
+
   if ~exist('var', 'var')
-     nm = []; val = []; label = []; units = [];
+    nm = []; val = []; label = []; units = [];
   else
     [nm, val, units, label] = prtStat(taxon, var, 0);
     n = length(nm);
     for i = 1:n
-      tree = strrep(tree,nm{i},[nm{i}, ' ', num2str(val(i)), ' ', units]);
+      tree = strrep(tree, nm{i}, [nm{i}, ' ', num2str(val(i)), ' ', units]);
     end
     tree = [label, ': ', tree];
   end
-
 end
 
+
+%% build_pedigree_string
+% Recursively builds the indented tree string for all descendants of node.
+% Each child is prefixed with `level` tab characters; grandchildren with level+1, etc.
+function s = build_pedigree_string(node, TC, level)
+  s = '';
+  if ~isKey(TC.children, node)
+    return  % leaf node: no children to print
+  end
+  kids = TC.children(node);
+  tab  = repmat(char(9), 1, level);
+  for i = 1:numel(kids)
+    s = [s, tab, kids{i}, char(10), build_pedigree_string(kids{i}, TC, level + 1)]; %#ok<AGROW>
+  end
+end

--- a/select.m
+++ b/select.m
@@ -5,9 +5,10 @@
 function Species = select(taxon)
 % created 2015/09/18 by Bernd Brandt
 % modified 2015/10/07 by Dina Lika; 2016/11/08, 2021/11/24 by Bas Kooijman
+% modified 2025/06/07 by mrke: replaced Perl backend with MATLAB taxonomy cache
 
 %% Syntax
-% Species = <../select.m *select*> (taxon) 
+% Species = <../select.m *select*> (taxon)
 
 %% Description
 % gets all species in the add_my_pet collection that belong to a particular taxon or taxa.
@@ -17,11 +18,11 @@ function Species = select(taxon)
 % * taxon: optional character string or cell string with name{s} of taxon (default: 'Animalia')
 %
 % Output:
-% 
+%
 % * cell string with all species in the add_my_pet collection that belong to that taxon/taxa
 
 %% Remarks
-% The root is Animalia. 
+% The root is Animalia.
 % If chosen as taxon, an ordered list of all species in the collection results.
 % The classification follows that of Wikipedia.
 % See also <select_01.html *select_01*>
@@ -33,47 +34,37 @@ function Species = select(taxon)
 % reptile = setdiff(select('Sauropsida'), select('Maniraptora')) % select all classic reptilia, alphabetically ordered
 
   if ~exist('taxon', 'var')
-    taxon = {'Animalia'}; n = 1;
+    taxon = {'Animalia'};
   elseif ischar(taxon)
-    taxon = {taxon}; n = 1;
-  else
-    n = length(taxon);
+    taxon = {taxon};
   end
-  
-  WD = pwd;                   % store current path
-  taxa = which('select.pl');  % locate AmPtool_M/taxa/
-  taxa = taxa(1:end - 9);     % path to AmPtool_M/taxa/
-  cd(taxa)                    % goto taxa
-  
-  Species = {}; % initiate output
-  for i=1:n
-    if ~isempty(strfind(taxon{i}, '_')) % taxon{i} in an entry
-      taxa = textscan(perl('select.pl', 'Animalia'), '%s');
-      if ismember(taxon{i}, taxa{:})
-        species = taxon(i);
-      else        
-        disp(['Warning from select: Name ', taxon{i}, ' is not recognized as taxon'])
-        Species = {}; cd(WD); return
+  n = length(taxon);
+
+  TC = get_taxonomy_cache;
+  Species = {};
+
+  for i = 1:n
+    t = taxon{i};
+    if ~isempty(strfind(t, '_'))  % name contains '_' -> treat as a species entry
+      if isKey(TC.species_set, t)
+        Species = [Species; {t}]; %#ok<AGROW>
+      else
+        fprintf('Warning from select: Name %s is not recognized as taxon\n', t);
+        Species = {}; return
       end
-      
-    else % taxon{i} is not an entry
-      try
-        species = textscan(perl('select.pl', taxon{i}), '%s'); 
-        species = species{1};
-      catch        
-        disp(['Warning from select: Name ', taxon{i}, ' is not recognized as taxon'])
-        Species = {}; cd(WD); return
+    else  % treat as a taxon name
+      if isKey(TC.species_list, t)
+        Species = [Species; TC.species_list(t)]; %#ok<AGROW>
+      else
+        fprintf('Warning from select: Name %s is not recognized as taxon\n', t);
+        Species = {}; return
       end
     end
-    Species = [Species; species];
   end
-  
-  cd(WD) % goto original path
-  
-  wrong = Species(cellfun(@isempty, strfind(Species,'_')));
+
+  wrong = Species(cellfun(@isempty, strfind(Species, '_')));
   if ~isempty(wrong)
     fprintf('Warning from select: not all cells are entry names\n')
-    wrong
+    disp(wrong)
   end
 end
-


### PR DESCRIPTION
This PR removes dependency on perl for taxonomy lookups - instead builds a cache (should be about 5-10 mb) for faster performance